### PR TITLE
test arrival atis validation

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -34,3 +34,7 @@ def test_atis_validate_runways_in_use():
     atis_data["text_atis"] = "RUNWAYS IN USE 26L AND 26R"
     atis_with_text = Atis.model_validate(atis_data)
     assert set(atis_with_text.runways_in_use) == {"26L", "26R"}
+
+    atis_data["callsign"] = "ZZZZ_A_ATIS"
+    atis_arrival = Atis.model_validate(atis_data)
+    assert atis_arrival.callsign == "ZZZZ"


### PR DESCRIPTION
:100: 
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/fpletz/python-vatsim/tree/main) ([f6d42f8](https://github.com/fpletz/python-vatsim/commit/f6d42f8bf835423554d81b7b031572e1a94cf191)) | [#8](https://github.com/fpletz/python-vatsim/pull/8) ([e00ba78](https://github.com/fpletz/python-vatsim/commit/e00ba78070a937a57a05238bbb731ce6c9149949)) |  +/-  |
|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                          99.4% |                                                                                                                                                    100.0% | +0.6% |
| **Test Execution Time** |                                                                                                                                                             2s |                                                                                                                                                        3s |   +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (f6d42f8) | #8 (e00ba78) |  +/-  |
  |---------------------|----------------|--------------|-------|
+ | Coverage            |          99.4% |       100.0% | +0.6% |
  |   Files             |              4 |            4 |     0 |
  |   Lines             |            164 |          164 |     0 |
+ |   Covered           |            163 |          164 |    +1 |
- | Test Execution Time |             2s |           3s |   +1s |
```

</details>


### Code coverage of files in pull request scope (99.3% → 100.0%)

|                                                               Files                                                                | Coverage |  +/-  |
|------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|
| [tests/test_types.py](https://github.com/fpletz/python-vatsim/blob/da789518aaed9869435a0449dc19f8e7ee11e6b7/tests%2Ftest_types.py) | 100.0%   | +0.7% |

---
Reported by octocov
<!-- octocov -->
